### PR TITLE
Fix compilation in MacOS for Xcode 10.2.1 by

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	add_compile_options(/arch:AVX)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	add_compile_options("-mavx")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+    add_compile_options("-mavx")
 endif()
 
 set(EIGEN3_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/extern/eigen")
@@ -65,8 +67,9 @@ if (WIN32)
   add_dependencies(FastCorotDemo freeglut)
 else()
   find_package(GLUT REQUIRED)
-endif()	
-	
+endif()
+
+set_target_properties(FastCorotDemo PROPERTIES CXX_STANDARD 11)
 target_link_libraries(FastCorotDemo ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
 
 add_definitions(-DDATA_PATH="${PROJECT_PATH}/meshes/")

--- a/FastCorotFEM.h
+++ b/FastCorotFEM.h
@@ -91,7 +91,7 @@ public:
 			std::vector<Scalarf8, AlignmentAllocator<Scalarf8, 32>>& vAVX);
 
 	void convertToAVX(
-			const std::vector<Real[4][3]>& v, 
+                      const std::vector<Eigen::Matrix<Real,4,3>>& v, 
 			std::vector<std::vector<std::vector<Scalarf8, AlignmentAllocator<Scalarf8, 32>>>>& vAVX);
 };
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -2,7 +2,12 @@
 #include "utilities/MiniGL.h"
 #include "utilities/Timing.h"
 #include "TetModel.h"
+
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include "GL/glut.h"
+#endif
 
 INIT_TIMING
 

--- a/utilities/MiniGL.cpp
+++ b/utilities/MiniGL.cpp
@@ -9,13 +9,13 @@
 #ifdef __APPLE__
 #include <OpenGL/GL.h>
 #include <OpenGL/GLU.h>
+#include <GLUT/glut.h>
 #else
 #include "GL/gl.h"
 #include "GL/glu.h"
-#endif
-
 #include "GL/glut.h"
 #include "GL/freeglut_ext.h"
+#endif
 
 #define _USE_MATH_DEFINES
 
@@ -944,7 +944,7 @@ void MiniGL::breakPointMainLoop()
 		m_breakPointLoop = true;
 		while (m_breakPointLoop)
 		{
-			glutMainLoopEvent();
+			glutMainLoop();
 		}
 	}
 }


### PR DESCRIPTION
* explicitly setting c++11 in cmake to allow >> without space at end of templates
* adjusting glut includes for mac
* using Eigens handmade aligned allocator because std::aligned_allocator is missing in Apple Clang
* switching from [4][3] to fix-size Eigen matrix to fix error in deletion in std::vector

Changes only tested on MacOs 10.14.4 and XCod3 10.2.1. Please test with MSVC and linux if you want to avoid regressions.